### PR TITLE
chore: drop redundant main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "undo"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
   "name": "@echecs/game",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- removed redundant `"main": "dist/index.js"` from `package.json` (already covered by `"exports"`)