### PR TITLE
chore: import Move and PromotionPieceType from @echecs/position

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
   "types": "dist/index.d.ts",
   "version": "3.0.0",
   "dependencies": {
-    "@echecs/position": "^3.0.3"
+    "@echecs/position": "^3.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@echecs/position':
-        specifier: ^3.0.3
-        version: 3.0.5
+        specifier: ^3.1.0
+        version: 3.1.0
     devDependencies:
       '@echecs/fen':
         specifier: ^2.0.0
@@ -121,8 +121,8 @@ packages:
     resolution: {integrity: sha512-VVgSn9llXDlHmNJ3J27dLnkFEWPzpa0iZCr8ZfUhpOuLBd2Yan/6+aa/mCy3RD9qbe/KgZuh8Ljw5j1PlemFFw==}
     engines: {node: '>=20'}
 
-  '@echecs/position@3.0.5':
-    resolution: {integrity: sha512-YUkBF/yrIebHABZPebRHsIZGhHT6unk9WwxVE98AvoeTYfAAg+8SjpyjLstKxYqvBxyWP6SEIFj0Ad6p5zIH3Q==}
+  '@echecs/position@3.1.0':
+    resolution: {integrity: sha512-NjyPnbq4NaNfhbEtFTW61/qKLsR+BkFeus9Z/RIaHEJI7Kr0WWkjyKoU3t6FNUjFr5m+QkjV2jo6vzfElpS5hw==}
     engines: {node: '>=20'}
 
   '@echecs/san@3.0.0':
@@ -1772,13 +1772,13 @@ snapshots:
 
   '@echecs/fen@2.1.1': {}
 
-  '@echecs/position@3.0.5':
+  '@echecs/position@3.1.0':
     dependencies:
       '@echecs/zobrist': 1.0.2
 
   '@echecs/san@3.0.0':
     dependencies:
-      '@echecs/position': 3.0.5
+      '@echecs/position': 3.1.0
 
   '@echecs/zobrist@1.0.2': {}
 

--- a/src/detection.ts
+++ b/src/detection.ts
@@ -1,5 +1,4 @@
-import type { Move } from './types.js';
-import type { Position } from '@echecs/position';
+import type { Move, Position } from '@echecs/position';
 
 function isCheckmate(position: Position, moves: Move[]): boolean {
   return position.isCheck && moves.length === 0;

--- a/src/game.ts
+++ b/src/game.ts
@@ -3,8 +3,8 @@ import { Position, STARTING_POSITION } from '@echecs/position';
 import { isCheckmate, isDraw, isStalemate } from './detection.js';
 import { move as applyMove, generateMoves } from './moves.js';
 
-import type { Move, MoveResult } from './types.js';
-import type { Color, Piece, Square } from '@echecs/position';
+import type { MoveResult } from './types.js';
+import type { Color, Move, Piece, Square } from '@echecs/position';
 
 function reverseMoveResult(result: MoveResult): MoveResult {
   const reversed: MoveResult = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 export { Game } from './game.js';
 export { STARTING_POSITION, Position } from '@echecs/position';
-export type { Move, MoveResult, PromotionPieceType } from './types.js';
+export type { MoveResult } from './types.js';
 export type {
   CastlingRights,
   Color,
   EnPassantSquare,
+  Move,
   Piece,
   PieceType,
+  PromotionPieceType,
   SideCastlingRights,
   Square,
 } from '@echecs/position';

--- a/src/moves.ts
+++ b/src/moves.ts
@@ -1,10 +1,12 @@
-import type { Move, MoveResult, PromotionPieceType } from './types.js';
+import type { MoveResult } from './types.js';
 import type {
   CastlingRights,
   Color,
   EnPassantSquare,
+  Move,
   Piece,
   Position,
+  PromotionPieceType,
   Square,
 } from '@echecs/position';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,4 @@
-import type { Piece, PieceType, Square } from '@echecs/position';
-
-type PromotionPieceType = Exclude<PieceType, 'king' | 'pawn'>;
-
-interface Move {
-  from: Square;
-  promotion?: PromotionPieceType;
-  to: Square;
-}
+import type { Piece, Square } from '@echecs/position';
 
 interface MoveResult {
   from: Square;
@@ -24,4 +16,4 @@ interface MoveResult {
   };
 }
 
-export type { Move, MoveResult, PromotionPieceType };
+export type { MoveResult };


### PR DESCRIPTION
closes #23

`@echecs/position` 3.1.0 now exports `Move` and `PromotionPieceType`. drop the local definitions in `src/types.ts` and import from position instead. `MoveResult` stays local — it's game-specific.

non-breaking — same types, same shapes, same names.