### PR TITLE
feat: replace MoveResult with Movement[]

### DIFF
--- a/docs/superpowers/plans/2026-04-29-movement-type.md
+++ b/docs/superpowers/plans/2026-04-29-movement-type.md
@@ -1,0 +1,733 @@
+# Replace `MoveResult` with `Movement[]` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `MoveResult` with an ordered `Movement[]` that uniformly
+describes all board changes — forward and backward — without information loss.
+
+**Architecture:** Delete `MoveResult`, add `Movement` type. Rewrite the result
+construction in `move()` (moves.ts) to build `Movement[]`. Update `Game` class
+to drop stored results from history, compute movements on demand, and reverse
+them for undo. Update all tests.
+
+**Tech Stack:** TypeScript, vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-29-movement-type-design.md`
+
+---
+
+### Task 1: Replace `MoveResult` type with `Movement` in `src/types.ts`
+
+**Files:**
+
+- Modify: `src/types.ts`
+
+- [ ] **Step 1: Replace `MoveResult` with `Movement`**
+
+Replace the entire contents of `src/types.ts` with:
+
+```typescript
+import type { Piece, Square } from '@echecs/position';
+
+interface Movement {
+  from: Square | undefined;
+  to: Square | undefined;
+  piece: Piece;
+}
+
+export type { Movement };
+```
+
+- [ ] **Step 2: Verify types compile**
+
+Run: `pnpm lint:types` Expected: Failures in `game.ts`, `moves.ts`, `index.ts`
+referencing `MoveResult`. This is expected — we fix those in later tasks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "refactor: replace MoveResult type with Movement"
+```
+
+---
+
+### Task 2: Update public exports in `src/index.ts`
+
+**Files:**
+
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Replace `MoveResult` export with `Movement`**
+
+Change line 3 from:
+
+```typescript
+export type { MoveResult } from './types.js';
+```
+
+to:
+
+```typescript
+export type { Movement } from './types.js';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "refactor: export Movement instead of MoveResult"
+```
+
+---
+
+### Task 3: Rewrite `move()` in `src/moves.ts` to return `Movement[]`
+
+**Files:**
+
+- Modify: `src/moves.ts`
+
+- [ ] **Step 1: Update the import**
+
+Change line 1 from:
+
+```typescript
+import type { MoveResult } from './types.js';
+```
+
+to:
+
+```typescript
+import type { Movement } from './types.js';
+```
+
+- [ ] **Step 2: Update the `move()` function signature and return type**
+
+Change the function signature (line 207-210) from:
+
+```typescript
+function move(
+  position: Position,
+  m: Move,
+): { position: Position; result: MoveResult } {
+```
+
+to:
+
+```typescript
+function move(
+  position: Position,
+  m: Move,
+): { movements: Movement[]; position: Position } {
+```
+
+- [ ] **Step 3: Update the early return for missing piece**
+
+Change lines 211-221 from:
+
+```typescript
+const piece = position.at(m.from);
+if (piece === undefined) {
+  return {
+    position,
+    result: {
+      from: m.from,
+      piece: { color: 'white', type: 'pawn' },
+      to: m.to,
+    },
+  };
+}
+```
+
+to:
+
+```typescript
+const piece = position.at(m.from);
+if (piece === undefined) {
+  return { movements: [], position };
+}
+```
+
+- [ ] **Step 4: Replace `MoveResult` construction with `Movement[]`
+      construction**
+
+Replace lines 339-375 (the `// Build MoveResult` block through the castling
+result) with:
+
+```typescript
+// Build Movement[]
+const movements: Movement[] = [];
+
+if (piece.type === 'pawn' && m.promotion !== undefined) {
+  // Promotion: pawn disappears, promoted piece appears
+  movements.push({ from: m.from, piece, to: undefined });
+  movements.push({
+    from: undefined,
+    piece: { color: piece.color, type: m.promotion },
+    to: m.to,
+  });
+} else {
+  // Primary movement
+  movements.push({ from: m.from, piece, to: m.to });
+}
+
+// Castling: rook relocation
+if (isCastling) {
+  const rank = m.from[1] as string;
+  const rook: Piece = { color: piece.color, type: 'rook' };
+  movements.push(
+    toFile === 'g'
+      ? { from: `h${rank}` as Square, piece: rook, to: `f${rank}` as Square }
+      : { from: `a${rank}` as Square, piece: rook, to: `d${rank}` as Square },
+  );
+}
+
+// Captures
+if (isEnPassant) {
+  const capturedFile = m.to[0] as string;
+  const capturedRank = m.from[1] as string;
+  const capturedSquare = `${capturedFile}${capturedRank}` as Square;
+  const capturedPiece = position.at(capturedSquare);
+  if (capturedPiece !== undefined) {
+    movements.push({
+      from: capturedSquare,
+      piece: capturedPiece,
+      to: undefined,
+    });
+  }
+} else if (isCapture) {
+  const capturedPiece = position.at(m.to);
+  if (capturedPiece !== undefined) {
+    movements.push({ from: m.to, piece: capturedPiece, to: undefined });
+  }
+}
+```
+
+- [ ] **Step 5: Update the return statement**
+
+Change line 377 from:
+
+```typescript
+return { position: newPosition, result };
+```
+
+to:
+
+```typescript
+return { movements, position: newPosition };
+```
+
+- [ ] **Step 6: Verify types compile**
+
+Run: `pnpm lint:types` Expected: Failures in `game.ts` only (still references
+`MoveResult` and `result`). `moves.ts` should compile cleanly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/moves.ts
+git commit -m "refactor: move() returns Movement[] instead of MoveResult"
+```
+
+---
+
+### Task 4: Update `Game` class in `src/game.ts`
+
+**Files:**
+
+- Modify: `src/game.ts`
+
+- [ ] **Step 1: Update imports**
+
+Change line 6 from:
+
+```typescript
+import type { MoveResult } from './types.js';
+```
+
+to:
+
+```typescript
+import type { Movement } from './types.js';
+```
+
+- [ ] **Step 2: Delete `reverseMoveResult` function**
+
+Delete lines 9-25 (the entire `reverseMoveResult` function).
+
+- [ ] **Step 3: Update `HistoryEntry` interface**
+
+Replace:
+
+```typescript
+interface HistoryEntry {
+  move: Move;
+  previousPosition: Position;
+  result: MoveResult;
+}
+```
+
+with:
+
+```typescript
+interface HistoryEntry {
+  move: Move;
+  position: Position;
+}
+```
+
+- [ ] **Step 4: Update `move()` method**
+
+Replace the `move()` method body. Change:
+
+```typescript
+  move(input: Move): MoveResult {
+    const legalFromSquare = this.#cachedState.moves.filter(
+      (mv) => mv.from === input.from,
+    );
+    const isLegal = legalFromSquare.some(
+      (mv) => mv.to === input.to && mv.promotion === input.promotion,
+    );
+
+    if (!isLegal) {
+      throw new Error(this.#illegalMoveReason(input, legalFromSquare));
+    }
+
+    this.#cache = undefined;
+    const previousPosition = this.#position;
+    const { position, result } = applyMove(this.#position, input);
+    this.#position = position;
+    this.#past.push({ move: input, previousPosition, result });
+    this.#future = [];
+    this.#positionHistory.push(this.#position.hash);
+
+    return result;
+  }
+```
+
+to:
+
+```typescript
+  move(input: Move): Movement[] {
+    const legalFromSquare = this.#cachedState.moves.filter(
+      (mv) => mv.from === input.from,
+    );
+    const isLegal = legalFromSquare.some(
+      (mv) => mv.to === input.to && mv.promotion === input.promotion,
+    );
+
+    if (!isLegal) {
+      throw new Error(this.#illegalMoveReason(input, legalFromSquare));
+    }
+
+    this.#cache = undefined;
+    const position = this.#position;
+    const { movements, position: newPosition } = applyMove(this.#position, input);
+    this.#position = newPosition;
+    this.#past.push({ move: input, position });
+    this.#future = [];
+    this.#positionHistory.push(this.#position.hash);
+
+    return movements;
+  }
+```
+
+- [ ] **Step 5: Update `undo()` method**
+
+Replace:
+
+```typescript
+  undo(): MoveResult | undefined {
+    const entry = this.#past.pop();
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    this.#cache = undefined;
+    this.#position = entry.previousPosition;
+    this.#future.push(entry);
+    this.#positionHistory.pop();
+
+    return reverseMoveResult(entry.result);
+  }
+```
+
+with:
+
+```typescript
+  undo(): Movement[] | undefined {
+    const entry = this.#past.pop();
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    this.#cache = undefined;
+    this.#position = entry.position;
+    this.#future.push(entry);
+    this.#positionHistory.pop();
+
+    const { movements } = applyMove(entry.position, entry.move);
+    const swap = (m: Movement) => ({
+      from: m.to,
+      piece: m.piece,
+      to: m.from,
+    });
+    const activeColor = entry.position.turn;
+    const active = movements
+      .filter((m) => m.piece.color === activeColor)
+      .reverse()
+      .map(swap);
+    const opponent = movements
+      .filter((m) => m.piece.color !== activeColor)
+      .reverse()
+      .map(swap);
+
+    return [...active, ...opponent];
+  }
+```
+
+- [ ] **Step 6: Update `redo()` method**
+
+Replace:
+
+```typescript
+  redo(): MoveResult | undefined {
+    const entry = this.#future.pop();
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    this.#cache = undefined;
+    const { position } = applyMove(entry.previousPosition, entry.move);
+    this.#position = position;
+    this.#past.push(entry);
+    this.#positionHistory.push(this.#position.hash);
+
+    return entry.result;
+  }
+```
+
+with:
+
+```typescript
+  redo(): Movement[] | undefined {
+    const entry = this.#future.pop();
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    this.#cache = undefined;
+    const { movements, position } = applyMove(entry.position, entry.move);
+    this.#position = position;
+    this.#past.push(entry);
+    this.#positionHistory.push(this.#position.hash);
+
+    return movements;
+  }
+```
+
+- [ ] **Step 7: Update JSDoc on `move()` method**
+
+Change the JSDoc comment from:
+
+```typescript
+  /**
+   * Applies a move and returns a {@link MoveResult} describing what happened.
+   * Clears the redo stack.
+```
+
+to:
+
+```typescript
+  /**
+   * Applies a move and returns a {@link Movement} array describing all board
+   * changes. Clears the redo stack.
+```
+
+- [ ] **Step 8: Verify types compile**
+
+Run: `pnpm lint:types` Expected: PASS — all `MoveResult` references removed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/game.ts
+git commit -m "refactor: Game class uses Movement[] for move/undo/redo"
+```
+
+---
+
+### Task 5: Update `move()` return value tests
+
+**Files:**
+
+- Modify: `src/__tests__/game.spec.ts`
+
+- [ ] **Step 1: Write failing tests for `move()` returning `Movement[]`**
+
+Replace the `describe('move()', ...)` block (lines 25-89) with:
+
+```typescript
+describe('move()', () => {
+  it('applies a legal move and returns Movement[]', () => {
+    const game = new Game();
+    const result = game.move({ from: 'e2', to: 'e4' });
+    expect(game.get('e4')).toEqual({ color: 'white', type: 'pawn' });
+    expect(game.get('e2')).toBeUndefined();
+    expect(result).toEqual([
+      { from: 'e2', to: 'e4', piece: { color: 'white', type: 'pawn' } },
+    ]);
+  });
+
+  it('switches turn after move', () => {
+    const game = new Game();
+    game.move({ from: 'e2', to: 'e4' });
+    expect(game.turn()).toBe('black');
+  });
+
+  it('throws on illegal move', () => {
+    expect(() => new Game().move({ from: 'e2', to: 'e5' })).toThrow(
+      /^Illegal move:/,
+    );
+  });
+
+  it('returns Movement[] with capture', () => {
+    const game = new Game();
+    game.move({ from: 'e2', to: 'e4' });
+    game.move({ from: 'd7', to: 'd5' });
+    const result = game.move({ from: 'e4', to: 'd5' });
+    expect(result).toEqual([
+      { from: 'e4', to: 'd5', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns Movement[] with castling', () => {
+    const game = new Game(
+      fromFen('r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1'),
+    );
+    const result = game.move({ from: 'e1', to: 'g1' });
+    expect(result).toEqual([
+      { from: 'e1', to: 'g1', piece: { color: 'white', type: 'king' } },
+      { from: 'h1', to: 'f1', piece: { color: 'white', type: 'rook' } },
+    ]);
+  });
+
+  it('returns Movement[] with promotion', () => {
+    const game = new Game(fromFen('k7/4P3/8/8/8/8/8/K7 w - - 0 1'));
+    const result = game.move({ from: 'e7', to: 'e8', promotion: 'queen' });
+    expect(result).toEqual([
+      { from: 'e7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'e8', piece: { color: 'white', type: 'queen' } },
+    ]);
+  });
+
+  it('returns Movement[] with promotion and capture', () => {
+    const game = new Game(fromFen('k2r4/4P3/8/8/8/8/8/K7 w - - 0 1'));
+    const result = game.move({ from: 'e7', to: 'd8', promotion: 'queen' });
+    expect(result).toEqual([
+      { from: 'e7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'd8', piece: { color: 'white', type: 'queen' } },
+      { from: 'd8', to: undefined, piece: { color: 'black', type: 'rook' } },
+    ]);
+  });
+
+  it('returns Movement[] with en passant', () => {
+    const game = new Game(
+      fromFen('rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3'),
+    );
+    const result = game.move({ from: 'e5', to: 'd6' });
+    expect(result).toEqual([
+      { from: 'e5', to: 'd6', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pnpm test src/__tests__/game.spec.ts -- --reporter=verbose -t "move()"`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/game.spec.ts
+git commit -m "test: update move() tests to assert Movement[]"
+```
+
+---
+
+### Task 6: Update `undo()` return value tests
+
+**Files:**
+
+- Modify: `src/__tests__/game.spec.ts`
+
+- [ ] **Step 1: Replace `undo()` return value tests**
+
+Replace the `describe('undo() return value', ...)` block (lines 266-319) with:
+
+```typescript
+describe('undo() return value', () => {
+  it('returns undefined when nothing to undo', () => {
+    const game = new Game();
+    expect(game.undo()).toBeUndefined();
+  });
+
+  it('returns reversed Movement[] for a normal move', () => {
+    const game = new Game();
+    game.move({ from: 'e2', to: 'e4' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'e4', to: 'e2', piece: { color: 'white', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with capture (uncapture)', () => {
+    const game = new Game();
+    game.move({ from: 'e2', to: 'e4' });
+    game.move({ from: 'd7', to: 'd5' });
+    game.move({ from: 'e4', to: 'd5' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'd5', to: 'e4', piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'd5', piece: { color: 'black', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with en passant (uncapture)', () => {
+    const game = new Game(
+      fromFen('rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3'),
+    );
+    game.move({ from: 'e5', to: 'd6' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'd6', to: 'e5', piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'd5', piece: { color: 'black', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with castling', () => {
+    const game = new Game(
+      fromFen('r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1'),
+    );
+    game.move({ from: 'e1', to: 'g1' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'g1', to: 'e1', piece: { color: 'white', type: 'king' } },
+      { from: 'f1', to: 'h1', piece: { color: 'white', type: 'rook' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with promotion (depromotion)', () => {
+    const game = new Game(fromFen('k7/4P3/8/8/8/8/8/K7 w - - 0 1'));
+    game.move({ from: 'e7', to: 'e8', promotion: 'queen' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: undefined, to: 'e7', piece: { color: 'white', type: 'pawn' } },
+      { from: 'e8', to: undefined, piece: { color: 'white', type: 'queen' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with promotion and capture', () => {
+    const game = new Game(fromFen('k2r4/4P3/8/8/8/8/8/K7 w - - 0 1'));
+    game.move({ from: 'e7', to: 'd8', promotion: 'queen' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: undefined, to: 'e7', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd8', to: undefined, piece: { color: 'white', type: 'queen' } },
+      { from: undefined, to: 'd8', piece: { color: 'black', type: 'rook' } },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pnpm test src/__tests__/game.spec.ts -- --reporter=verbose -t "undo"`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/game.spec.ts
+git commit -m "test: update undo() tests to assert reversed Movement[]"
+```
+
+---
+
+### Task 7: Update `redo()` return value tests
+
+**Files:**
+
+- Modify: `src/__tests__/game.spec.ts`
+
+- [ ] **Step 1: Replace `redo()` return value tests**
+
+Replace the `describe('redo() return value', ...)` block (lines 322-352) with:
+
+```typescript
+describe('redo() return value', () => {
+  it('returns undefined when nothing to redo', () => {
+    const game = new Game();
+    expect(game.redo()).toBeUndefined();
+  });
+
+  it('returns forward Movement[]', () => {
+    const game = new Game();
+    game.move({ from: 'e2', to: 'e4' });
+    game.undo();
+    const result = game.redo();
+    expect(result).toEqual([
+      { from: 'e2', to: 'e4', piece: { color: 'white', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns forward Movement[] with capture', () => {
+    const game = new Game();
+    game.move({ from: 'e2', to: 'e4' });
+    game.move({ from: 'd7', to: 'd5' });
+    game.move({ from: 'e4', to: 'd5' });
+    game.undo();
+    const result = game.redo();
+    expect(result).toEqual([
+      { from: 'e4', to: 'd5', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pnpm test` Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/game.spec.ts
+git commit -m "test: update redo() tests to assert Movement[]"
+```
+
+---
+
+### Task 8: Run lint, types, and build
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run lint**
+
+Run: `pnpm lint` Expected: PASS
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pnpm test` Expected: All tests PASS.
+
+- [ ] **Step 3: Run build**
+
+Run: `pnpm build` Expected: PASS — clean build output in `dist/`.

--- a/docs/superpowers/specs/2026-04-29-movement-type-design.md
+++ b/docs/superpowers/specs/2026-04-29-movement-type-design.md
@@ -1,0 +1,192 @@
+# Replace `MoveResult` with `Movement[]`
+
+Closes #28.
+
+## Problem
+
+`MoveResult` describes a chess move using named fields (`captured`, `castling`,
+`promotion`). This works for forward moves but breaks on undo —
+`reverseMoveResult` invents a synthetic reverse move that loses information
+(drops captures, drops promotions, swaps from/to to describe a move that never
+happened).
+
+The root cause is that `MoveResult` can only represent forward chess moves. An
+undo is a history operation, not a chess move — there is no way to represent
+"uncapturing" a piece in the current type.
+
+## Solution
+
+Replace `MoveResult` with `Movement[]` — an ordered list of individual piece
+movements that describe every board change, forward or backward.
+
+### `Movement` type
+
+```ts
+interface Movement {
+  from: Square | undefined;
+  to: Square | undefined;
+  piece: Piece;
+}
+```
+
+Semantics:
+
+- `from` defined, `to` defined — piece moves from one square to another
+- `from` defined, `to` undefined — piece removed from the board (capture)
+- `from` undefined, `to` defined — piece appears on the board (uncapture on
+  undo, promoted piece appearing)
+
+### Ordering
+
+Active color first, then opponent color. Within active color: primary movement
+first, then transformations.
+
+1. **Primary movement** — the piece the player moved
+2. **Transformations** — promotion (pawn disappears, promoted piece appears)
+3. **Captures** — opponent piece removed
+
+Examples:
+
+**Normal move** (e2 to e4):
+
+```ts
+[{ from: 'e2', to: 'e4', piece: { color: 'white', type: 'pawn' } }];
+```
+
+**Capture** (Nf3 captures pawn on d5):
+
+```ts
+[
+  { from: 'f3', to: 'd5', piece: { color: 'white', type: 'knight' } },
+  { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+];
+```
+
+**En passant** (e5 captures pawn on d5 via d6):
+
+```ts
+[
+  { from: 'e5', to: 'd6', piece: { color: 'white', type: 'pawn' } },
+  { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+];
+```
+
+**Kingside castling**:
+
+```ts
+[
+  { from: 'e1', to: 'g1', piece: { color: 'white', type: 'king' } },
+  { from: 'h1', to: 'f1', piece: { color: 'white', type: 'rook' } },
+];
+```
+
+**Promotion** (pawn promotes to queen):
+
+```ts
+[
+  { from: 'e7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+  { from: undefined, to: 'e8', piece: { color: 'white', type: 'queen' } },
+];
+```
+
+**Promotion with capture** (pawn captures rook on d8, promotes to queen):
+
+```ts
+[
+  { from: 'e7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+  { from: undefined, to: 'd8', piece: { color: 'white', type: 'queen' } },
+  { from: 'd8', to: undefined, piece: { color: 'black', type: 'rook' } },
+];
+```
+
+**Undo of capture** (Nf3xd5 undone):
+
+```ts
+[
+  { from: 'd5', to: 'f3', piece: { color: 'white', type: 'knight' } },
+  { from: undefined, to: 'd5', piece: { color: 'black', type: 'pawn' } },
+];
+```
+
+**Undo of en passant** (e5->d6 undone):
+
+```ts
+[
+  { from: 'd6', to: 'e5', piece: { color: 'white', type: 'pawn' } },
+  { from: undefined, to: 'd5', piece: { color: 'black', type: 'pawn' } },
+];
+```
+
+**Undo of promotion**:
+
+```ts
+[
+  { from: 'e8', to: undefined, piece: { color: 'white', type: 'queen' } },
+  { from: undefined, to: 'e7', piece: { color: 'white', type: 'pawn' } },
+];
+```
+
+**Undo of promotion with capture** (pawn captured rook on d8, promoted to
+queen):
+
+```ts
+[
+  { from: 'd8', to: undefined, piece: { color: 'white', type: 'queen' } },
+  { from: undefined, to: 'e7', piece: { color: 'white', type: 'pawn' } },
+  { from: undefined, to: 'd8', piece: { color: 'black', type: 'rook' } },
+];
+```
+
+## API changes
+
+| Method        | Before                    | After                     |
+| ------------- | ------------------------- | ------------------------- |
+| `move(input)` | `MoveResult`              | `Movement[]`              |
+| `undo()`      | `MoveResult \| undefined` | `Movement[] \| undefined` |
+| `redo()`      | `MoveResult \| undefined` | `Movement[] \| undefined` |
+
+Breaking change — requires major version bump.
+
+## Internal changes
+
+### `src/types.ts`
+
+- Delete `MoveResult` interface
+- Add `Movement` interface
+
+### `src/moves.ts`
+
+- `move()` returns `{ position: Position, movements: Movement[] }` instead of
+  `{ position: Position, result: MoveResult }`
+- Build `Movement[]` from the same data already computed (piece, capture,
+  castling, promotion detection)
+
+### `src/game.ts`
+
+- `HistoryEntry` becomes `{ position: Position, move: Move }` — drop `result`
+- Delete `reverseMoveResult` function
+- `move()` returns `Movement[]` from `applyMove`
+- `undo()` recomputes `Movement[]` for the undone move via
+  `applyMove(entry.position, entry.move)`, then reverses each movement (swap
+  `from`/`to`)
+- `redo()` recomputes `Movement[]` via `applyMove(entry.position, entry.move)`
+
+### `src/index.ts`
+
+- Export `Movement` type instead of `MoveResult`
+
+## Undo reversal
+
+`undo()` computes the forward `Movement[]` and produces the reverse:
+
+- Swap `from` and `to` on each movement
+- Active color movements come first, opponent color second
+- No ordering guarantee within the same color group
+
+## Testing
+
+- Update existing `MoveResult` tests to assert `Movement[]` for each move type
+- Add undo tests for captures, en passant, castling, and promotion — verify the
+  reversed movements include uncaptures and depromotions
+- Existing perft, detection, and playthrough tests should be unaffected (they
+  don't inspect `MoveResult`)

--- a/src/__tests__/game.spec.ts
+++ b/src/__tests__/game.spec.ts
@@ -23,16 +23,14 @@ describe('new Game()', () => {
 });
 
 describe('move()', () => {
-  it('applies a legal move and returns MoveResult', () => {
+  it('applies a legal move and returns Movement[]', () => {
     const game = new Game();
     const result = game.move({ from: 'e2', to: 'e4' });
     expect(game.get('e4')).toEqual({ color: 'white', type: 'pawn' });
     expect(game.get('e2')).toBeUndefined();
-    expect(result).toEqual({
-      from: 'e2',
-      to: 'e4',
-      piece: { color: 'white', type: 'pawn' },
-    });
+    expect(result).toEqual([
+      { from: 'e2', to: 'e4', piece: { color: 'white', type: 'pawn' } },
+    ]);
   });
 
   it('switches turn after move', () => {
@@ -47,45 +45,56 @@ describe('move()', () => {
     );
   });
 
-  it('returns MoveResult with capture info', () => {
+  it('returns Movement[] with capture', () => {
     const game = new Game();
     game.move({ from: 'e2', to: 'e4' });
     game.move({ from: 'd7', to: 'd5' });
     const result = game.move({ from: 'e4', to: 'd5' });
-    expect(result.captured).toEqual({
-      square: 'd5',
-      piece: { color: 'black', type: 'pawn' },
-    });
+    expect(result).toEqual([
+      { from: 'e4', to: 'd5', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+    ]);
   });
 
-  it('returns MoveResult with castling info', () => {
+  it('returns Movement[] with castling', () => {
     const game = new Game(
       fromFen('r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1'),
     );
     const result = game.move({ from: 'e1', to: 'g1' });
-    expect(result.castling).toEqual({
-      from: 'h1',
-      to: 'f1',
-      piece: { color: 'white', type: 'rook' },
-    });
+    expect(result).toEqual([
+      { from: 'e1', to: 'g1', piece: { color: 'white', type: 'king' } },
+      { from: 'h1', to: 'f1', piece: { color: 'white', type: 'rook' } },
+    ]);
   });
 
-  it('returns MoveResult with promotion info', () => {
+  it('returns Movement[] with promotion', () => {
     const game = new Game(fromFen('k7/4P3/8/8/8/8/8/K7 w - - 0 1'));
     const result = game.move({ from: 'e7', to: 'e8', promotion: 'queen' });
-    expect(result.promotion).toEqual({ color: 'white', type: 'queen' });
-    expect(result.piece).toEqual({ color: 'white', type: 'pawn' });
+    expect(result).toEqual([
+      { from: 'e7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'e8', piece: { color: 'white', type: 'queen' } },
+    ]);
   });
 
-  it('returns MoveResult with en passant capture', () => {
+  it('returns Movement[] with promotion and capture', () => {
+    const game = new Game(fromFen('k2r4/4P3/8/8/8/8/8/K7 w - - 0 1'));
+    const result = game.move({ from: 'e7', to: 'd8', promotion: 'queen' });
+    expect(result).toEqual([
+      { from: 'e7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'd8', piece: { color: 'white', type: 'queen' } },
+      { from: 'd8', to: undefined, piece: { color: 'black', type: 'rook' } },
+    ]);
+  });
+
+  it('returns Movement[] with en passant', () => {
     const game = new Game(
       fromFen('rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3'),
     );
     const result = game.move({ from: 'e5', to: 'd6' });
-    expect(result.captured).toEqual({
-      square: 'd5',
-      piece: { color: 'black', type: 'pawn' },
-    });
+    expect(result).toEqual([
+      { from: 'e5', to: 'd6', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+    ]);
   });
 });
 
@@ -269,53 +278,70 @@ describe('undo() return value', () => {
     expect(game.undo()).toBeUndefined();
   });
 
-  it('returns reversed MoveResult for a normal move', () => {
+  it('returns reversed Movement[] for a normal move', () => {
     const game = new Game();
     game.move({ from: 'e2', to: 'e4' });
     const result = game.undo();
-    expect(result).toEqual({
-      from: 'e4',
-      to: 'e2',
-      piece: { color: 'white', type: 'pawn' },
-    });
+    expect(result).toEqual([
+      { from: 'e4', to: 'e2', piece: { color: 'white', type: 'pawn' } },
+    ]);
   });
 
-  it('returns reversed MoveResult for castling', () => {
-    const game = new Game(
-      fromFen('r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1'),
-    );
-    game.move({ from: 'e1', to: 'g1' });
-    const result = game.undo();
-    expect(result).toEqual({
-      from: 'g1',
-      to: 'e1',
-      piece: { color: 'white', type: 'king' },
-      castling: {
-        from: 'f1',
-        to: 'h1',
-        piece: { color: 'white', type: 'rook' },
-      },
-    });
-  });
-
-  it('returns reversed MoveResult for promotion (piece is the promoted piece)', () => {
-    const game = new Game(fromFen('k7/4P3/8/8/8/8/8/K7 w - - 0 1'));
-    game.move({ from: 'e7', to: 'e8', promotion: 'queen' });
-    const result = game.undo();
-    expect(result).toEqual({
-      from: 'e8',
-      to: 'e7',
-      piece: { color: 'white', type: 'queen' },
-    });
-  });
-
-  it('omits captured on undo', () => {
+  it('returns reversed Movement[] with capture (uncapture)', () => {
     const game = new Game();
     game.move({ from: 'e2', to: 'e4' });
     game.move({ from: 'd7', to: 'd5' });
     game.move({ from: 'e4', to: 'd5' });
     const result = game.undo();
-    expect(result?.captured).toBeUndefined();
+    expect(result).toEqual([
+      { from: 'd5', to: 'e4', piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'd5', piece: { color: 'black', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with en passant (uncapture)', () => {
+    const game = new Game(
+      fromFen('rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3'),
+    );
+    game.move({ from: 'e5', to: 'd6' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'd6', to: 'e5', piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'd5', piece: { color: 'black', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with castling', () => {
+    const game = new Game(
+      fromFen('r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1'),
+    );
+    game.move({ from: 'e1', to: 'g1' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'f1', to: 'h1', piece: { color: 'white', type: 'rook' } },
+      { from: 'g1', to: 'e1', piece: { color: 'white', type: 'king' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with promotion (depromotion)', () => {
+    const game = new Game(fromFen('k7/4P3/8/8/8/8/8/K7 w - - 0 1'));
+    game.move({ from: 'e7', to: 'e8', promotion: 'queen' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'e8', to: undefined, piece: { color: 'white', type: 'queen' } },
+      { from: undefined, to: 'e7', piece: { color: 'white', type: 'pawn' } },
+    ]);
+  });
+
+  it('returns reversed Movement[] with promotion and capture', () => {
+    const game = new Game(fromFen('k2r4/4P3/8/8/8/8/8/K7 w - - 0 1'));
+    game.move({ from: 'e7', to: 'd8', promotion: 'queen' });
+    const result = game.undo();
+    expect(result).toEqual([
+      { from: 'd8', to: undefined, piece: { color: 'white', type: 'queen' } },
+      { from: undefined, to: 'e7', piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'd8', piece: { color: 'black', type: 'rook' } },
+    ]);
   });
 });
 
@@ -325,29 +351,27 @@ describe('redo() return value', () => {
     expect(game.redo()).toBeUndefined();
   });
 
-  it('returns the forward MoveResult', () => {
+  it('returns forward Movement[]', () => {
     const game = new Game();
     game.move({ from: 'e2', to: 'e4' });
     game.undo();
     const result = game.redo();
-    expect(result).toEqual({
-      from: 'e2',
-      to: 'e4',
-      piece: { color: 'white', type: 'pawn' },
-    });
+    expect(result).toEqual([
+      { from: 'e2', to: 'e4', piece: { color: 'white', type: 'pawn' } },
+    ]);
   });
 
-  it('returns forward MoveResult with capture info', () => {
+  it('returns forward Movement[] with capture', () => {
     const game = new Game();
     game.move({ from: 'e2', to: 'e4' });
     game.move({ from: 'd7', to: 'd5' });
     game.move({ from: 'e4', to: 'd5' });
     game.undo();
     const result = game.redo();
-    expect(result?.captured).toEqual({
-      square: 'd5',
-      piece: { color: 'black', type: 'pawn' },
-    });
+    expect(result).toEqual([
+      { from: 'e4', to: 'd5', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+    ]);
   });
 });
 

--- a/src/__tests__/moves.spec.ts
+++ b/src/__tests__/moves.spec.ts
@@ -121,16 +121,17 @@ describe('generateMoves — promotion', () => {
 });
 
 describe('move()', () => {
-  it('returns position and result', () => {
+  it('returns position and movements', () => {
     const position = fromFen(STARTING_FEN);
-    const { position: next, result } = move(position, { from: 'e2', to: 'e4' });
-    expect(next.at('e4')).toEqual({ color: 'white', type: 'pawn' });
-    expect(next.at('e2')).toBeUndefined();
-    expect(result).toEqual({
+    const { position: next, movements } = move(position, {
       from: 'e2',
       to: 'e4',
-      piece: { color: 'white', type: 'pawn' },
     });
+    expect(next.at('e4')).toEqual({ color: 'white', type: 'pawn' });
+    expect(next.at('e2')).toBeUndefined();
+    expect(movements).toEqual([
+      { from: 'e2', to: 'e4', piece: { color: 'white', type: 'pawn' } },
+    ]);
   });
 
   it('sets en passant square on double pawn push', () => {
@@ -145,77 +146,75 @@ describe('move()', () => {
     expect(next.turn).toBe('black');
   });
 
-  it('result includes captured piece', () => {
+  it('movements includes captured piece', () => {
     const fen =
       'rnbqkb1r/ppp1pppp/5n2/3p4/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3';
     const position = fromFen(fen);
-    const { result } = move(position, { from: 'e4', to: 'd5' });
-    expect(result.captured).toEqual({
-      square: 'd5',
+    const { movements } = move(position, { from: 'e4', to: 'd5' });
+    expect(movements).toContainEqual({
+      from: 'd5',
+      to: undefined,
       piece: { color: 'black', type: 'pawn' },
     });
   });
 
-  it('result includes en passant capture with correct square', () => {
+  it('movements includes en passant capture with correct square', () => {
     const fen = 'rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3';
     const position = fromFen(fen);
-    const { result } = move(position, { from: 'e5', to: 'd6' });
-    expect(result.captured).toEqual({
-      square: 'd5',
-      piece: { color: 'black', type: 'pawn' },
-    });
-    expect(result.from).toBe('e5');
-    expect(result.to).toBe('d6');
+    const { movements } = move(position, { from: 'e5', to: 'd6' });
+    expect(movements).toEqual([
+      { from: 'e5', to: 'd6', piece: { color: 'white', type: 'pawn' } },
+      { from: 'd5', to: undefined, piece: { color: 'black', type: 'pawn' } },
+    ]);
   });
 
-  it('result includes castling rook movement (kingside)', () => {
+  it('movements includes castling rook movement (kingside)', () => {
     const fen = 'r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1';
     const position = fromFen(fen);
-    const { result } = move(position, { from: 'e1', to: 'g1' });
-    expect(result.piece).toEqual({ color: 'white', type: 'king' });
-    expect(result.castling).toEqual({
-      from: 'h1',
-      to: 'f1',
-      piece: { color: 'white', type: 'rook' },
-    });
+    const { movements } = move(position, { from: 'e1', to: 'g1' });
+    expect(movements).toEqual([
+      { from: 'e1', to: 'g1', piece: { color: 'white', type: 'king' } },
+      { from: 'h1', to: 'f1', piece: { color: 'white', type: 'rook' } },
+    ]);
   });
 
-  it('result includes castling rook movement (queenside)', () => {
+  it('movements includes castling rook movement (queenside)', () => {
     const fen = 'r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1';
     const position = fromFen(fen);
-    const { result } = move(position, { from: 'e1', to: 'c1' });
-    expect(result.castling).toEqual({
-      from: 'a1',
-      to: 'd1',
-      piece: { color: 'white', type: 'rook' },
-    });
+    const { movements } = move(position, { from: 'e1', to: 'c1' });
+    expect(movements).toEqual([
+      { from: 'e1', to: 'c1', piece: { color: 'white', type: 'king' } },
+      { from: 'a1', to: 'd1', piece: { color: 'white', type: 'rook' } },
+    ]);
   });
 
-  it('result includes promotion piece', () => {
+  it('movements includes promotion piece', () => {
     const fen = 'k7/4P3/8/8/8/8/8/K7 w - - 0 1';
     const position = fromFen(fen);
-    const { result } = move(position, {
+    const { movements } = move(position, {
       from: 'e7',
       to: 'e8',
       promotion: 'queen',
     });
-    expect(result.piece).toEqual({ color: 'white', type: 'pawn' });
-    expect(result.promotion).toEqual({ color: 'white', type: 'queen' });
+    expect(movements).toEqual([
+      { from: 'e7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'e8', piece: { color: 'white', type: 'queen' } },
+    ]);
   });
 
-  it('result includes both capture and promotion', () => {
+  it('movements includes both capture and promotion', () => {
     const fen = 'k3r3/3P4/8/8/8/8/8/K7 w - - 0 1';
     const position = fromFen(fen);
-    const { result } = move(position, {
+    const { movements } = move(position, {
       from: 'd7',
       to: 'e8',
       promotion: 'queen',
     });
-    expect(result.captured).toEqual({
-      square: 'e8',
-      piece: { color: 'black', type: 'rook' },
-    });
-    expect(result.promotion).toEqual({ color: 'white', type: 'queen' });
+    expect(movements).toEqual([
+      { from: 'd7', to: undefined, piece: { color: 'white', type: 'pawn' } },
+      { from: undefined, to: 'e8', piece: { color: 'white', type: 'queen' } },
+      { from: 'e8', to: undefined, piece: { color: 'black', type: 'rook' } },
+    ]);
   });
 });
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -3,31 +3,12 @@ import { Position, STARTING_POSITION } from '@echecs/position';
 import { isCheckmate, isDraw, isStalemate } from './detection.js';
 import { move as applyMove, generateMoves } from './moves.js';
 
-import type { MoveResult } from './types.js';
+import type { Movement } from './types.js';
 import type { Color, Move, Piece, Square } from '@echecs/position';
-
-function reverseMoveResult(result: MoveResult): MoveResult {
-  const reversed: MoveResult = {
-    from: result.to,
-    piece: result.promotion ?? result.piece,
-    to: result.from,
-  };
-
-  if (result.castling) {
-    reversed.castling = {
-      from: result.castling.to,
-      piece: result.castling.piece,
-      to: result.castling.from,
-    };
-  }
-
-  return reversed;
-}
 
 interface HistoryEntry {
   move: Move;
-  previousPosition: Position;
-  result: MoveResult;
+  position: Position;
 }
 
 /**
@@ -192,7 +173,7 @@ export class Game {
   }
 
   /**
-   * Applies a move and returns a {@link MoveResult} describing what happened.
+   * Applies a move and returns a {@link Movement} array describing all board changes.
    * Clears the redo stack.
    *
    * @throws Error if the move is illegal, with a descriptive message
@@ -207,7 +188,7 @@ export class Game {
    * game.move({ from: 'e7', to: 'e8', promotion: 'queen' });
    * ```
    */
-  move(input: Move): MoveResult {
+  move(input: Move): Movement[] {
     const legalFromSquare = this.#cachedState.moves.filter(
       (mv) => mv.from === input.from,
     );
@@ -220,14 +201,17 @@ export class Game {
     }
 
     this.#cache = undefined;
-    const previousPosition = this.#position;
-    const { position, result } = applyMove(this.#position, input);
-    this.#position = position;
-    this.#past.push({ move: input, previousPosition, result });
+    const position = this.#position;
+    const { movements, position: newPosition } = applyMove(
+      this.#position,
+      input,
+    );
+    this.#position = newPosition;
+    this.#past.push({ move: input, position });
     this.#future = [];
     this.#positionHistory.push(this.#position.hash);
 
-    return result;
+    return movements;
   }
 
   /**
@@ -261,19 +245,19 @@ export class Game {
    * @remarks The redo stack is cleared whenever a new {@link move} is
    * made.
    */
-  redo(): MoveResult | undefined {
+  redo(): Movement[] | undefined {
     const entry = this.#future.pop();
     if (entry === undefined) {
       return undefined;
     }
 
     this.#cache = undefined;
-    const { position } = applyMove(entry.previousPosition, entry.move);
+    const { movements, position } = applyMove(entry.position, entry.move);
     this.#position = position;
     this.#past.push(entry);
     this.#positionHistory.push(this.#position.hash);
 
-    return entry.result;
+    return movements;
   }
 
   /** Returns the color whose turn it is to move: `'white'` or `'black'`. */
@@ -282,17 +266,28 @@ export class Game {
   }
 
   /** Steps back one move. No-op at the start of the game. */
-  undo(): MoveResult | undefined {
+  undo(): Movement[] | undefined {
     const entry = this.#past.pop();
     if (entry === undefined) {
       return undefined;
     }
 
     this.#cache = undefined;
-    this.#position = entry.previousPosition;
+    this.#position = entry.position;
     this.#future.push(entry);
     this.#positionHistory.pop();
 
-    return reverseMoveResult(entry.result);
+    const { movements } = applyMove(entry.position, entry.move);
+    const activeColor = entry.position.turn;
+    const active = movements
+      .filter((m) => m.piece.color === activeColor)
+      .toReversed()
+      .map((m) => ({ from: m.to, piece: m.piece, to: m.from }));
+    const opponent = movements
+      .filter((m) => m.piece.color !== activeColor)
+      .toReversed()
+      .map((m) => ({ from: m.to, piece: m.piece, to: m.from }));
+
+    return [...active, ...opponent];
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { Game } from './game.js';
 export { STARTING_POSITION, Position } from '@echecs/position';
-export type { MoveResult } from './types.js';
+export type { Movement } from './types.js';
 export type {
   CastlingRights,
   Color,

--- a/src/moves.ts
+++ b/src/moves.ts
@@ -1,4 +1,4 @@
-import type { MoveResult } from './types.js';
+import type { Movement } from './types.js';
 import type {
   CastlingRights,
   Color,
@@ -201,23 +201,16 @@ function boardChanges(
 }
 
 /**
- * Apply a move to a Position, returning the new Position and a MoveResult.
+ * Apply a move to a Position, returning the new Position and a Movement[].
  * Does not validate legality — assumes the move is valid.
  */
 function move(
   position: Position,
   m: Move,
-): { position: Position; result: MoveResult } {
+): { movements: Movement[]; position: Position } {
   const piece = position.at(m.from);
   if (piece === undefined) {
-    return {
-      position,
-      result: {
-        from: m.from,
-        piece: { color: 'white', type: 'pawn' },
-        to: m.to,
-      },
-    };
+    return { movements: [], position };
   }
 
   const changes = boardChanges(position, m);
@@ -336,45 +329,56 @@ function move(
     turn,
   });
 
-  // Build MoveResult
-  const result: MoveResult = { from: m.from, piece, to: m.to };
+  // Build Movement[]
+  const movements: Movement[] = [];
 
+  if (piece.type === 'pawn' && m.promotion !== undefined) {
+    // Promotion: pawn disappears, promoted piece appears
+    movements.push(
+      { from: m.from, piece, to: undefined },
+      {
+        from: undefined,
+        piece: { color: piece.color, type: m.promotion },
+        to: m.to,
+      },
+    );
+  } else {
+    // Primary movement
+    movements.push({ from: m.from, piece, to: m.to });
+  }
+
+  // Castling: rook relocation
+  if (isCastling) {
+    const rank = m.from[1] as string;
+    const rook: Piece = { color: piece.color, type: 'rook' };
+    movements.push(
+      toFile === 'g'
+        ? { from: `h${rank}` as Square, piece: rook, to: `f${rank}` as Square }
+        : { from: `a${rank}` as Square, piece: rook, to: `d${rank}` as Square },
+    );
+  }
+
+  // Captures
   if (isEnPassant) {
     const capturedFile = m.to[0] as string;
     const capturedRank = m.from[1] as string;
     const capturedSquare = `${capturedFile}${capturedRank}` as Square;
     const capturedPiece = position.at(capturedSquare);
     if (capturedPiece !== undefined) {
-      result.captured = { piece: capturedPiece, square: capturedSquare };
+      movements.push({
+        from: capturedSquare,
+        piece: capturedPiece,
+        to: undefined,
+      });
     }
   } else if (isCapture) {
     const capturedPiece = position.at(m.to);
     if (capturedPiece !== undefined) {
-      result.captured = { piece: capturedPiece, square: m.to };
+      movements.push({ from: m.to, piece: capturedPiece, to: undefined });
     }
   }
 
-  if (piece.type === 'pawn' && m.promotion !== undefined) {
-    result.promotion = { color: piece.color, type: m.promotion };
-  }
-
-  if (isCastling) {
-    const rank = m.from[1] as string;
-    result.castling =
-      toFile === 'g'
-        ? {
-            from: `h${rank}` as Square,
-            piece: { color: piece.color, type: 'rook' },
-            to: `f${rank}` as Square,
-          }
-        : {
-            from: `a${rank}` as Square,
-            piece: { color: piece.color, type: 'rook' },
-            to: `d${rank}` as Square,
-          };
-  }
-
-  return { position: newPosition, result };
+  return { movements, position: newPosition };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,9 @@
 import type { Piece, Square } from '@echecs/position';
 
-interface MoveResult {
-  from: Square;
-  to: Square;
+interface Movement {
+  from: Square | undefined;
+  to: Square | undefined;
   piece: Piece;
-  captured?: {
-    square: Square;
-    piece: Piece;
-  };
-  promotion?: Piece;
-  castling?: {
-    from: Square;
-    to: Square;
-    piece: Piece;
-  };
 }
 
-export type { MoveResult };
+export type { Movement };


### PR DESCRIPTION
Closes #28.

## Summary

- Replaces `MoveResult` with `Movement[]` — a flat ordered list of `{ from, to, piece }` where `undefined` means a piece appears or disappears from the board
- `move()`, `undo()`, and `redo()` all return `Movement[]` (or `Movement[] | undefined`)
- `undo()` now returns lossless reversed movements — captures become uncaptures, promotions become depromotions
- Deletes `reverseMoveResult` and trims `HistoryEntry` to `{ position, move }`
- Results are computed on demand, not stored in history

**Breaking change** — `MoveResult` type no longer exists.