### PR TITLE
chore: update @echecs deps (position v4, san v3.1.3, fen v3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   },
   "description": "Chess game engine with legal move generation, check/checkmate/stalemate detection, and undo/redo. Strict TypeScript.",
   "devDependencies": {
-    "@echecs/fen": "^2.0.0",
-    "@echecs/san": "^3.0.0",
+    "@echecs/fen": "^3.0.0",
+    "@echecs/san": "^3.1.3",
     "@eslint/js": "^10.0.1",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitest/coverage-v8": "^4.1.0",
@@ -85,6 +85,6 @@
   "types": "dist/index.d.ts",
   "version": "4.0.0",
   "dependencies": {
-    "@echecs/position": "^3.1.0"
+    "@echecs/position": "^4.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,15 +9,15 @@ importers:
   .:
     dependencies:
       '@echecs/position':
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@echecs/fen':
-        specifier: ^2.0.0
-        version: 2.1.1
-      '@echecs/san':
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(@echecs/position@4.0.0)
+      '@echecs/san':
+        specifier: ^3.1.3
+        version: 3.1.3(@echecs/position@4.0.0)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
@@ -117,17 +117,21 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@echecs/fen@2.1.1':
-    resolution: {integrity: sha512-VVgSn9llXDlHmNJ3J27dLnkFEWPzpa0iZCr8ZfUhpOuLBd2Yan/6+aa/mCy3RD9qbe/KgZuh8Ljw5j1PlemFFw==}
+  '@echecs/fen@3.0.0':
+    resolution: {integrity: sha512-cJ423Pa7Mtb8Va83AQv5fRA/34p4zy+NydyK1CGHXxRyTOCprJe0CGmRyL4zbFE25ezjpsXn7Uw81HdfSC4+Kg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@echecs/position': ^4.0.0
+
+  '@echecs/position@4.0.0':
+    resolution: {integrity: sha512-D9z+d13owPg/EEyEp2nfqhE8gbDCdWvsoULstW4bRrums0J/i3Nxc9yz7XADe8dFhV4nqAYCanrZBk9Sr6aIIw==}
     engines: {node: '>=20'}
 
-  '@echecs/position@3.1.0':
-    resolution: {integrity: sha512-NjyPnbq4NaNfhbEtFTW61/qKLsR+BkFeus9Z/RIaHEJI7Kr0WWkjyKoU3t6FNUjFr5m+QkjV2jo6vzfElpS5hw==}
+  '@echecs/san@3.1.3':
+    resolution: {integrity: sha512-Cjcpt5dEksG5p/tIiPfAxnU1MhmD2Kl3ADOQasH0P0FHgUArn5amkd5MeHTnjDyltqOhjNa1BsGZcS4MVNvBCA==}
     engines: {node: '>=20'}
-
-  '@echecs/san@3.0.0':
-    resolution: {integrity: sha512-vmUG/1qY9I8CFj0LlF+jJFD7hmPxzcqPhdNTLIdMmcccP41G6FiOk+kKY6LgiGZOqwrpy0v4UBQriPKv9y2u7A==}
-    engines: {node: '>=20'}
+    peerDependencies:
+      '@echecs/position': ^4.0.0
 
   '@echecs/zobrist@1.0.2':
     resolution: {integrity: sha512-X2HtxAhP8zuiE9IaTJ0uM9kccQjGR9zseXZGnIB3zJmpCYcA3TBGiAceLqrtYgyjK4dpIOH5F+0R25bOWlW3Xg==}
@@ -1308,8 +1312,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1369,8 +1373,8 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1770,15 +1774,17 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@echecs/fen@2.1.1': {}
+  '@echecs/fen@3.0.0(@echecs/position@4.0.0)':
+    dependencies:
+      '@echecs/position': 4.0.0
 
-  '@echecs/position@3.1.0':
+  '@echecs/position@4.0.0':
     dependencies:
       '@echecs/zobrist': 1.0.2
 
-  '@echecs/san@3.0.0':
+  '@echecs/san@3.1.3(@echecs/position@4.0.0)':
     dependencies:
-      '@echecs/position': 3.1.0
+      '@echecs/position': 4.0.0
 
   '@echecs/zobrist@1.0.2': {}
 
@@ -2828,7 +2834,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -2873,9 +2879,9 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss@8.5.12:
+  postcss@8.5.13:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3150,7 +3156,7 @@ snapshots:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.13
       rolldown: 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/src/__tests__/hash.spec.ts
+++ b/src/__tests__/hash.spec.ts
@@ -6,8 +6,8 @@ import { fromFen } from './helpers.js';
 
 describe('zobrist hash consistency', () => {
   it('starting position has a consistent hash', () => {
-    const pos1 = new Position(STARTING_POSITION);
-    const pos2 = new Position(STARTING_POSITION);
+    const pos1 = new Position({ board: STARTING_POSITION });
+    const pos2 = new Position({ board: STARTING_POSITION });
     expect(pos1.hash).toBe(pos2.hash);
     expect(pos1.hash).toMatch(/^[\da-f]{16}$/);
   });

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -7,13 +7,7 @@ function fromFen(fen: string): Position {
     throw new Error(`Invalid FEN in test: ${fen}`);
   }
 
-  return new Position(parsed.board, {
-    castlingRights: parsed.castlingRights,
-    enPassantSquare: parsed.enPassantSquare,
-    fullmoveNumber: parsed.fullmoveNumber,
-    halfmoveClock: parsed.halfmoveClock,
-    turn: parsed.turn,
-  });
+  return new Position(parsed);
 }
 
 export { fromFen };

--- a/src/game.ts
+++ b/src/game.ts
@@ -40,7 +40,7 @@ export class Game {
    * ```
    */
   constructor(position?: Position) {
-    this.#position = position ?? new Position(STARTING_POSITION);
+    this.#position = position ?? new Position({ board: STARTING_POSITION });
     this.#positionHistory = [this.#position.hash];
   }
 


### PR DESCRIPTION
- **@echecs/position** `^3.1.0` -> `^4.0.0` — constructor changed from `(board, options)` to `(data?: PositionData)`
- **@echecs/san** `^3.0.0` -> `3.1.3` — now uses `peerDependencies` + `external` in tsdown, fixes duplicate type resolution under pnpm strict hoisting
- **@echecs/fen** `^2.0.0` -> `3.0.0` — `parse()` returns `PositionData` directly

adapted `Game` constructor, test helpers, and hash tests to the new `Position(data?)` signature.

supersedes #29.