### PR TITLE
chore: align .gitignore with canonical template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ coverage/
 # Documentation
 docs/api/*
 !docs/api/.gitkeep
-.playwright-mcp/
-release.yml
 
 # Agent planning artifacts
 .superpowers/


### PR DESCRIPTION
aligns .gitignore to the canonical trf template — removes stale entries