### PR TITLE
chore: add publishConfig for public access

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
   ],
   "license": "MIT",
   "name": "@echecs/game",
+  "publishConfig": {
+    "access": "public"
+  },
   "packageManager": "pnpm@10.33.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
scoped packages default to restricted on npm — this ensures public access is explicit