### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "homepage": "https://github.com/echecsjs/game#readme",
+  "homepage": "https://game.echecs.dev",
   "keywords": [
     "board",
     "checkmate",


### PR DESCRIPTION
points homepage to the docs site instead of the github repo