### PR TITLE
chore: disable minimumReleaseAge for dependabot compatibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   unrs-resolver: true
+minimumReleaseAge: 0


### PR DESCRIPTION
pnpm 11 blocks recently-published packages by default. this causes dependabot PRs to fail CI when they bump a package published within the last 24h. disabling the check since dependabot version pinning and CI already provide sufficient protection.