### PR TITLE
fix: ignore __tests__ directory in unicorn/filename-case

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,6 +56,13 @@ export default typescript.config(
       'no-console': 'warn',
       'sort-imports': ['error', { ignoreDeclarationSort: true }],
       'sort-keys': 'error',
+      'unicorn/filename-case': [
+        'error',
+        {
+          case: 'kebabCase',
+          ignore: [/^__tests__$/],
+        },
+      ],
     },
   },
   /**


### PR DESCRIPTION
unicorn v65 started enforcing `filename-case` on directory names. `__tests__` gets flagged as not kebab-case. adds an ignore pattern.